### PR TITLE
Updated Packet Tests by Replacing Outdated RxName Usage and Enhanced …

### DIFF
--- a/feature/b2b/ospfv2/ospfv2_p2p_lsa_test.go
+++ b/feature/b2b/ospfv2/ospfv2_p2p_lsa_test.go
@@ -252,14 +252,12 @@ func ospfv2P2pLsasOk(api *otg.OtgApi, tc map[string]interface{}) bool {
 			routerLsas[0].Header().AdvertisingRouterId() == advRouterId &&
 			routerLsas[0].Header().LsaId() == routerLsaId &&
 			len(routerLsas[0].Links().Items()) == 2 {
-			links := routerLsas[0].Links().Items()
-			if links[0].Type() == gosnappi.Ospfv2LinkType.POINT_TO_POINT &&
-				links[0].Metric() == 0 &&
-				links[0].Id() == routerLsaLinkId &&
-				links[0].Data() == routerLsaLinkData &&
-				links[1].Type() == gosnappi.Ospfv2LinkType.STUB &&
-				links[1].Metric() == 0 {
-				lsaCount += 1
+			for _, link := range routerLsas[0].Links().Items() {
+				if (link.Type() == gosnappi.Ospfv2LinkType.STUB && (link.Metric() == 0 || link.Metric() == 1)) ||
+					(link.Type() == gosnappi.Ospfv2LinkType.POINT_TO_POINT && link.Id() == routerLsaLinkId &&
+						link.Data() == routerLsaLinkData && (link.Metric() == 0 || link.Metric() == 1)) {
+					lsaCount += 1
+				}
 			}
 		}
 	}

--- a/feature/b2b/ospfv2/test_ospfv2_p2p_lsa.py
+++ b/feature/b2b/ospfv2/test_ospfv2_p2p_lsa.py
@@ -26,7 +26,7 @@ def test_ospfv2_p2p_lsa():
 
     api = otg.OtgApi()
     c = ospfv2_p2p_lsa_config(api, test_const)
-
+    api.api.request_timeout = 300
     api.set_config(c)
 
     api.start_protocols()
@@ -195,20 +195,20 @@ def ospfv2_lsas_ok(api, tc):
             and m.network_summary_lsas[0].header.lsa_id == nw_summary_lsa_id
         ):
             lsa_count += 1
-
         if (
             len(m.router_lsas) == 1
             and m.router_lsas[0].header.advertising_router_id == adv_router_id
             and m.router_lsas[0].header.lsa_id == router_lsa_id
             and len(m.router_lsas[0].links) == 2
-            and m.router_lsas[0].links[0].type == "point_to_point"
-            and m.router_lsas[0].links[0].metric == 0
-            and m.router_lsas[0].links[0].id == router_lsa_link_id
-            and m.router_lsas[0].links[0].data == router_lsa_link_data
-            and m.router_lsas[0].links[1].type == "stub"
-            and m.router_lsas[0].links[1].metric == 0
         ):
-            lsa_count += 1
+            for link in (m.router_lsas[0].links):
+                if ((link.type == "stub"
+                    and link.metric == 0 or 1) or (link.type == "point_to_point"
+                    and link.id == router_lsa_link_id
+                    and link.data == router_lsa_link_data
+                    and link.metric == 0 or 1)
+                ):
+                    lsa_count += 1
 
     return lsa_count == 4
 

--- a/feature/b2b/packet/tcp/tcp_port_incr_decr_test.go
+++ b/feature/b2b/packet/tcp/tcp_port_incr_decr_test.go
@@ -64,7 +64,7 @@ func tcpPortIncrDecrConfig(api *otg.OtgApi, tc map[string]interface{}) gosnappi.
 	f1 := c.Flows().Add().SetName("f1")
 	f1.TxRx().Port().
 		SetTxName(p1.Name()).
-		SetRxName(p2.Name())
+		SetRxNames([]string{p2.Name()})
 	f1.Duration().FixedPackets().SetPackets(tc["pktCount"].(uint32))
 	f1.Rate().SetPps(tc["pktRate"].(uint64))
 	f1.Size().SetFixed(tc["pktSize"].(uint32))

--- a/feature/b2b/packet/tcp/tcp_port_value_test.go
+++ b/feature/b2b/packet/tcp/tcp_port_value_test.go
@@ -60,7 +60,7 @@ func tcpPortValueConfig(api *otg.OtgApi, tc map[string]interface{}) gosnappi.Con
 	f1 := c.Flows().Add().SetName("f1")
 	f1.TxRx().Port().
 		SetTxName(p1.Name()).
-		SetRxName(p2.Name())
+		SetRxNames([]string{p2.Name()})
 	f1.Duration().FixedPackets().SetPackets(tc["pktCount"].(uint32))
 	f1.Rate().SetPps(tc["pktRate"].(uint64))
 	f1.Size().SetFixed(tc["pktSize"].(uint32))

--- a/feature/b2b/packet/tcp/tcp_port_values_test.go
+++ b/feature/b2b/packet/tcp/tcp_port_values_test.go
@@ -60,7 +60,7 @@ func tcpPortValuesConfig(api *otg.OtgApi, tc map[string]interface{}) gosnappi.Co
 	f1 := c.Flows().Add().SetName("f1")
 	f1.TxRx().Port().
 		SetTxName(p1.Name()).
-		SetRxName(p2.Name())
+		SetRxNames([]string{p2.Name()})
 	f1.Duration().FixedPackets().SetPackets(tc["pktCount"].(uint32))
 	f1.Rate().SetPps(tc["pktRate"].(uint64))
 	f1.Size().SetFixed(tc["pktSize"].(uint32))

--- a/feature/b2b/packet/tcp/test_tcp_port_incr_decr.py
+++ b/feature/b2b/packet/tcp/test_tcp_port_incr_decr.py
@@ -23,7 +23,7 @@ def test_tcp_port_incr_decr():
     }
     api = otg.OtgApi()
     c = tcp_port_incr_decr_config(api, test_const)
-
+    api.api.request_timeout = 300
     api.set_config(c)
 
     api.start_capture()
@@ -52,7 +52,7 @@ def tcp_port_incr_decr_config(api, tc):
 
     f1 = c.flows.add(name="f1")
     f1.tx_rx.port.tx_name = p1.name
-    f1.tx_rx.port.rx_name = p2.name
+    f1.tx_rx.port.rx_names = [p2.name]
     f1.duration.fixed_packets.packets = tc["pktCount"]
     f1.rate.pps = tc["pktRate"]
     f1.size.fixed = tc["pktSize"]

--- a/feature/b2b/packet/tcp/test_tcp_port_value.py
+++ b/feature/b2b/packet/tcp/test_tcp_port_value.py
@@ -20,7 +20,7 @@ def test_tcp_port_value():
 
     api = otg.OtgApi()
     c = tcp_port_value_config(api, test_const)
-
+    api.api.request_timeout = 300
     api.set_config(c)
 
     api.start_capture()
@@ -49,7 +49,7 @@ def tcp_port_value_config(api, tc):
 
     f1 = c.flows.add(name="f1")
     f1.tx_rx.port.tx_name = p1.name
-    f1.tx_rx.port.rx_name = p2.name
+    f1.tx_rx.port.rx_names = [p2.name]
     f1.duration.fixed_packets.packets = tc["pktCount"]
     f1.rate.pps = tc["pktRate"]
     f1.size.fixed = tc["pktSize"]

--- a/feature/b2b/packet/tcp/test_tcp_port_values.py
+++ b/feature/b2b/packet/tcp/test_tcp_port_values.py
@@ -19,7 +19,7 @@ def test_tcp_port_values():
     }
     api = otg.OtgApi()
     c = tcp_port_values_config(api, test_const)
-
+    api.api.request_timeout = 300
     api.set_config(c)
 
     api.start_capture()
@@ -48,7 +48,7 @@ def tcp_port_values_config(api, tc):
 
     f1 = c.flows.add(name="f1")
     f1.tx_rx.port.tx_name = p1.name
-    f1.tx_rx.port.rx_name = p2.name
+    f1.tx_rx.port.rx_names = [p2.name]
     f1.duration.fixed_packets.packets = tc["pktCount"]
     f1.rate.pps = tc["pktRate"]
     f1.size.fixed = tc["pktSize"]

--- a/feature/b2b/packet/udp/ipv6_udp_port_values_test.go
+++ b/feature/b2b/packet/udp/ipv6_udp_port_values_test.go
@@ -60,7 +60,7 @@ func ipv6UdpPortValuesConfig(api *otg.OtgApi, tc map[string]interface{}) gosnapp
 	f1 := c.Flows().Add().SetName("f1")
 	f1.TxRx().Port().
 		SetTxName(p1.Name()).
-		SetRxName(p2.Name())
+		SetRxNames([]string{p2.Name()})
 	f1.Duration().FixedPackets().SetPackets(tc["pktCount"].(uint32))
 	f1.Rate().SetPps(tc["pktRate"].(uint64))
 	f1.Size().SetFixed(tc["pktSize"].(uint32))

--- a/feature/b2b/packet/udp/test_ipv6_udp_port_values.py
+++ b/feature/b2b/packet/udp/test_ipv6_udp_port_values.py
@@ -19,7 +19,7 @@ def test_ipv6_udp_port_values():
     }
     api = otg.OtgApi()
     c = ipv6_udp_port_values_config(api, test_const)
-
+    api.api.request_timeout = 300
     api.set_config(c)
 
     api.start_capture()
@@ -48,7 +48,7 @@ def ipv6_udp_port_values_config(api, tc):
 
     f1 = c.flows.add(name="f1")
     f1.tx_rx.port.tx_name = p1.name
-    f1.tx_rx.port.rx_name = p2.name
+    f1.tx_rx.port.rx_names = [p2.name]
     f1.duration.fixed_packets.packets = tc["pktCount"]
     f1.rate.pps = tc["pktRate"]
     f1.size.fixed = tc["pktSize"]

--- a/feature/b2b/packet/udp/test_udp_port_incr_decr.py
+++ b/feature/b2b/packet/udp/test_udp_port_incr_decr.py
@@ -23,7 +23,7 @@ def test_udp_port_incr_decr():
     }
     api = otg.OtgApi()
     c = udp_port_incr_decr_config(api, test_const)
-
+    api.api.request_timeout = 300
     api.set_config(c)
 
     api.start_capture()
@@ -52,7 +52,7 @@ def udp_port_incr_decr_config(api, tc):
 
     f1 = c.flows.add(name="f1")
     f1.tx_rx.port.tx_name = p1.name
-    f1.tx_rx.port.rx_name = p2.name
+    f1.tx_rx.port.rx_names = [p2.name]
     f1.duration.fixed_packets.packets = tc["pktCount"]
     f1.rate.pps = tc["pktRate"]
     f1.size.fixed = tc["pktSize"]

--- a/feature/b2b/packet/udp/test_udp_port_value.py
+++ b/feature/b2b/packet/udp/test_udp_port_value.py
@@ -20,7 +20,7 @@ def test_udp_port_value():
 
     api = otg.OtgApi()
     c = udp_port_value_config(api, test_const)
-
+    api.api.request_timeout = 300
     api.set_config(c)
 
     api.start_capture()
@@ -49,7 +49,7 @@ def udp_port_value_config(api, tc):
 
     f1 = c.flows.add(name="f1")
     f1.tx_rx.port.tx_name = p1.name
-    f1.tx_rx.port.rx_name = p2.name
+    f1.tx_rx.port.rx_names = [p2.name]
     f1.duration.fixed_packets.packets = tc["pktCount"]
     f1.rate.pps = tc["pktRate"]
     f1.size.fixed = tc["pktSize"]

--- a/feature/b2b/packet/udp/test_udp_port_values.py
+++ b/feature/b2b/packet/udp/test_udp_port_values.py
@@ -19,7 +19,7 @@ def test_udp_port_values():
     }
     api = otg.OtgApi()
     c = udp_port_values_config(api, test_const)
-
+    api.api.request_timeout = 300
     api.set_config(c)
 
     api.start_capture()
@@ -48,7 +48,7 @@ def udp_port_values_config(api, tc):
 
     f1 = c.flows.add(name="f1")
     f1.tx_rx.port.tx_name = p1.name
-    f1.tx_rx.port.rx_name = p2.name
+    f1.tx_rx.port.rx_names = [p2.name]
     f1.duration.fixed_packets.packets = tc["pktCount"]
     f1.rate.pps = tc["pktRate"]
     f1.size.fixed = tc["pktSize"]

--- a/feature/b2b/packet/udp/udp_port_incr_decr_test.go
+++ b/feature/b2b/packet/udp/udp_port_incr_decr_test.go
@@ -64,7 +64,7 @@ func udpPortIncrDecrConfig(api *otg.OtgApi, tc map[string]interface{}) gosnappi.
 	f1 := c.Flows().Add().SetName("f1")
 	f1.TxRx().Port().
 		SetTxName(p1.Name()).
-		SetRxName(p2.Name())
+		SetRxNames([]string{p2.Name()})
 	f1.Duration().FixedPackets().SetPackets(tc["pktCount"].(uint32))
 	f1.Rate().SetPps(tc["pktRate"].(uint64))
 	f1.Size().SetFixed(tc["pktSize"].(uint32))

--- a/feature/b2b/packet/udp/udp_port_value_eth0_test.go
+++ b/feature/b2b/packet/udp/udp_port_value_eth0_test.go
@@ -62,7 +62,7 @@ func udpPortValueEth0Config(api *otg.OtgApi, tc map[string]interface{}) gosnappi
 	f1 := c.Flows().Add().SetName("f1")
 	f1.TxRx().Port().
 		SetTxName(p1.Name()).
-		SetRxName(p2.Name())
+		SetRxNames([]string{p2.Name()})
 	f1.Duration().FixedPackets().SetPackets(tc["pktCount"].(uint32))
 	f1.Rate().SetPps(tc["pktRate"].(uint64))
 	f1.Size().SetFixed(tc["pktSize"].(uint32))

--- a/feature/b2b/packet/udp/udp_port_value_test.go
+++ b/feature/b2b/packet/udp/udp_port_value_test.go
@@ -60,7 +60,7 @@ func udpPortValueConfig(api *otg.OtgApi, tc map[string]interface{}) gosnappi.Con
 	f1 := c.Flows().Add().SetName("f1")
 	f1.TxRx().Port().
 		SetTxName(p1.Name()).
-		SetRxName(p2.Name())
+		SetRxNames([]string{p2.Name()})
 	f1.Duration().FixedPackets().SetPackets(tc["pktCount"].(uint32))
 	f1.Rate().SetPps(tc["pktRate"].(uint64))
 	f1.Size().SetFixed(tc["pktSize"].(uint32))

--- a/feature/b2b/packet/udp/udp_port_values_test.go
+++ b/feature/b2b/packet/udp/udp_port_values_test.go
@@ -60,7 +60,7 @@ func udpPortValuesConfig(api *otg.OtgApi, tc map[string]interface{}) gosnappi.Co
 	f1 := c.Flows().Add().SetName("f1")
 	f1.TxRx().Port().
 		SetTxName(p1.Name()).
-		SetRxName(p2.Name())
+		SetRxNames([]string{p2.Name()})
 	f1.Duration().FixedPackets().SetPackets(tc["pktCount"].(uint32))
 	f1.Rate().SetPps(tc["pktRate"].(uint64))
 	f1.Size().SetFixed(tc["pktSize"].(uint32))

--- a/feature/b2b/packet/vxlan/test_vxlan_inner_ipv4.py
+++ b/feature/b2b/packet/vxlan/test_vxlan_inner_ipv4.py
@@ -26,7 +26,7 @@ def test_vxlan_inner_ipv4():
     }
     api = otg.OtgApi()
     c = vxlan_inner_ipv4_config(api, test_const)
-
+    api.api.request_timeout = 300
     api.set_config(c)
 
     api.start_capture()
@@ -55,7 +55,7 @@ def vxlan_inner_ipv4_config(api, tc):
 
     f1 = c.flows.add(name="f1")
     f1.tx_rx.port.tx_name = p1.name
-    f1.tx_rx.port.rx_name = p2.name
+    f1.tx_rx.port.rx_names = [p2.name]
     f1.duration.fixed_packets.packets = tc["pktCount"]
     f1.rate.pps = tc["pktRate"]
     f1.size.fixed = tc["pktSize"]

--- a/feature/b2b/packet/vxlan/test_vxlan_inner_ipv6.py
+++ b/feature/b2b/packet/vxlan/test_vxlan_inner_ipv6.py
@@ -26,7 +26,7 @@ def test_vxlan_inner_ipv6():
     }
     api = otg.OtgApi()
     c = vxlan_inner_ipv6_config(api, test_const)
-
+    api.api.request_timeout = 300
     api.set_config(c)
 
     api.start_capture()
@@ -55,7 +55,7 @@ def vxlan_inner_ipv6_config(api, tc):
 
     f1 = c.flows.add(name="f1")
     f1.tx_rx.port.tx_name = p1.name
-    f1.tx_rx.port.rx_name = p2.name
+    f1.tx_rx.port.rx_names = [p2.name]
     f1.duration.fixed_packets.packets = tc["pktCount"]
     f1.rate.pps = tc["pktRate"]
     f1.size.fixed = tc["pktSize"]

--- a/feature/b2b/packet/vxlan/vxlan_inner_ipv4_test.go
+++ b/feature/b2b/packet/vxlan/vxlan_inner_ipv4_test.go
@@ -67,7 +67,7 @@ func vxlanInnerIpv4Config(api *otg.OtgApi, tc map[string]interface{}) gosnappi.C
 	f1 := c.Flows().Add().SetName("f1")
 	f1.TxRx().Port().
 		SetTxName(p1.Name()).
-		SetRxName(p2.Name())
+		SetRxNames([]string{p2.Name()})
 	f1.Duration().FixedPackets().SetPackets(tc["pktCount"].(uint32))
 	f1.Rate().SetPps(tc["pktRate"].(uint64))
 	f1.Size().SetFixed(tc["pktSize"].(uint32))

--- a/feature/b2b/packet/vxlan/vxlan_inner_ipv6_test.go
+++ b/feature/b2b/packet/vxlan/vxlan_inner_ipv6_test.go
@@ -67,7 +67,7 @@ func vxlanInnerIpv6Config(api *otg.OtgApi, tc map[string]interface{}) gosnappi.C
 	f1 := c.Flows().Add().SetName("f1")
 	f1.TxRx().Port().
 		SetTxName(p1.Name()).
-		SetRxName(p2.Name())
+		SetRxNames([]string{p2.Name()})
 	f1.Duration().FixedPackets().SetPackets(tc["pktCount"].(uint32))
 	f1.Rate().SetPps(tc["pktRate"].(uint64))
 	f1.Size().SetFixed(tc["pktSize"].(uint32))


### PR DESCRIPTION
…OSPFv2 Router LSA Validation

This PR includes the following updates and fixes:
	1.	Replaced outdated usage of the RxName field in tests with RxNames.
	2.	Introduced "api.api.request_timeout" in Python test cases to account for response delays from OTG.
	3.	Refined OSPFv2 Router LSA parsing logic to accommodate STC, which reports a stub link as the first entry in the Router LSA. The logic now validates based on link type.
	4.	Adjusted the OSPFv2 Router LSA metric handling to support both STC and Ixia. While STC uses a default metric value of 1, the original implementation assumed a value of 0 (likely from Ixia).
